### PR TITLE
Finance description changes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/finance/AddCommissionParser.java
+++ b/src/main/java/seedu/address/logic/parser/finance/AddCommissionParser.java
@@ -32,14 +32,14 @@ public class AddCommissionParser implements Parser<AddCommissionCommand> {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT, PREFIX_CLIENT, PREFIX_DESCRIPTION, PREFIX_TIME_DUE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_CLIENT)
+        if (!arePrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_CLIENT, PREFIX_DESCRIPTION)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommissionCommand.MESSAGE_USAGE));
         }
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_AMOUNT, PREFIX_CLIENT, PREFIX_DESCRIPTION);
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Person client = ParserUtil.parseClient(argMultimap.getValue(PREFIX_CLIENT).get());
-        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse(""));
+        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         LocalDateTime dateTime = DateTimeParser.parseDateTimeInstance(argMultimap.getValue(PREFIX_TIME_DUE)
                 .orElse("now"));
 

--- a/src/main/java/seedu/address/logic/parser/finance/AddExpenseParser.java
+++ b/src/main/java/seedu/address/logic/parser/finance/AddExpenseParser.java
@@ -32,7 +32,7 @@ public class AddExpenseParser implements Parser<AddExpenseCommand> {
         ArgumentMultimap argMultimap =
             ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT, PREFIX_CLIENT, PREFIX_DESCRIPTION, PREFIX_TIME_DUE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_AMOUNT)
+        if (!arePrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_DESCRIPTION)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExpenseCommand.MESSAGE_USAGE));
         }
@@ -42,7 +42,7 @@ public class AddExpenseParser implements Parser<AddExpenseCommand> {
         if (argMultimap.getValue(PREFIX_CLIENT).isPresent()) {
             client = ParserUtil.parseClient(argMultimap.getValue(PREFIX_CLIENT).get());
         }
-        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).orElse(""));
+        Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
         LocalDateTime dateTime = DateTimeParser.parseDateTimeInstance(argMultimap.getValue(PREFIX_TIME_DUE)
                 .orElse("now"));
 

--- a/src/main/java/seedu/address/model/finance/Description.java
+++ b/src/main/java/seedu/address/model/finance/Description.java
@@ -26,6 +26,9 @@ public class Description {
      * Returns true if a given string is a valid description.
      */
     public static boolean isValidDescription(String test) {
+        if (test.trim().equals("")) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/finance/Description.java
+++ b/src/main/java/seedu/address/model/finance/Description.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Description {
     public static final String MESSAGE_CONSTRAINTS =
-            "Descriptions can take any values up to 256 characters";
+            "Descriptions can take any values up to 256 characters and should not be blank.";
     public static final String VALIDATION_REGEX = "^(?!\\s)[\\s\\S]{0,256}$";
     public final String value;
     /**
@@ -17,6 +17,9 @@ public class Description {
      */
     public Description(String description) {
         requireNonNull(description);
+        if (description.trim().equals("")) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
+        }
         this.value = description;
     }
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -105,7 +105,7 @@ public class SampleDataUtil {
                             new Company(""),
                             new TelegramName("")
                     ),
-                    new Description(""),
+                    new Description("Chatbot"),
                     new TimeDue(LocalDateTime.now())
             ),
             new Expense(

--- a/src/main/resources/view/FinanceListCard.fxml
+++ b/src/main/resources/view/FinanceListCard.fxml
@@ -24,11 +24,11 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="client" text="\$first" styleClass="cell_big_label" />
+                <Label fx:id="description" text="\$first" styleClass="cell_big_label" />
             </HBox>
             <Label fx:id="amount" text="\$amount" />
             <Label fx:id="timeDue" styleClass="cell_small_label" text="\$timeDue" />
-            <Label fx:id="description" styleClass="cell_small_label" text="HELLO \$description"/>
+            <Label fx:id="client" styleClass="cell_small_label" text="HELLO \$client"/>
         </VBox>
     </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/parser/finance/AddCommissionParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/finance/AddCommissionParserTest.java
@@ -37,24 +37,22 @@ class AddCommissionParserTest {
     }
     @Test
     public void parse_failure() throws ParseException {
-        Commission expectedCommission = new CommissionBuilder().build();
-
-        String validExcpectedCommissionString = DEFAULT_AMOUNT + CLIENT_DESC_AMY + DEFAULT_DESCRIPTION;
+        String validExpectedCommissionString = DEFAULT_AMOUNT + CLIENT_DESC_AMY + DEFAULT_DESCRIPTION;
         // multiple clients
-        assertParseFailure(parser, CLIENT_DESC_BOB + validExcpectedCommissionString,
+        assertParseFailure(parser, CLIENT_DESC_BOB + validExpectedCommissionString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_CLIENT));
         // multiple amounts
-        assertParseFailure(parser, DEFAULT_AMOUNT + validExcpectedCommissionString,
+        assertParseFailure(parser, DEFAULT_AMOUNT + validExpectedCommissionString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_AMOUNT));
         // multiple descriptions
-        assertParseFailure(parser, DEFAULT_DESCRIPTION + validExcpectedCommissionString,
+        assertParseFailure(parser, DEFAULT_DESCRIPTION + validExpectedCommissionString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
     }
     @Test
     public void parse_optionalFieldsMissing_success() {
         // no description
-        Commission expectedCommission = new CommissionBuilder().withDescription("").build();
-        assertParseSuccess(parser, DEFAULT_AMOUNT + CLIENT_DESC_AMY + DEFAULT_TIME_DUE,
+        Commission expectedCommission = new CommissionBuilder().build();
+        assertParseSuccess(parser, DEFAULT_AMOUNT + CLIENT_DESC_AMY + DEFAULT_TIME_DUE + DEFAULT_DESCRIPTION,
                 new AddCommissionCommand(expectedCommission));
     }
     @Test

--- a/src/test/java/seedu/address/model/finance/ClientNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/finance/ClientNameContainsKeywordsPredicateTest.java
@@ -24,7 +24,12 @@ class ClientNameContainsKeywordsPredicateTest {
 
     @Test
     public void testTest_financeClientIsNull_returnsFalse() {
-        Finance finance = new Expense(new Amount("10"), null, new Description(""), new TimeDue(LocalDateTime.now()));
+        Finance finance = new Expense(
+                new Amount("10"),
+                null,
+                new Description("Test"),
+                new TimeDue(LocalDateTime.now())
+        );
         List<String> keywords = Arrays.asList("John");
         ClientNameContainsKeywordsPredicate predicate = new ClientNameContainsKeywordsPredicate(keywords);
         assertFalse(predicate.test(finance));

--- a/src/test/java/seedu/address/model/finance/ClientNameExactMatchPredicateTest.java
+++ b/src/test/java/seedu/address/model/finance/ClientNameExactMatchPredicateTest.java
@@ -21,7 +21,12 @@ class ClientNameExactMatchPredicateTest {
 
     @Test
     public void testTest_financeClientIsNull_returnsFalse() {
-        Finance finance = new Expense(new Amount("10"), null, new Description(""), new TimeDue(LocalDateTime.now()));
+        Finance finance = new Expense(
+                new Amount("10"),
+                null,
+                new Description("Test"),
+                new TimeDue(LocalDateTime.now())
+        );
         String clientName = "John Doe";
         ClientNameExactMatchPredicate predicate = new ClientNameExactMatchPredicate(clientName);
         assertFalse(predicate.test(finance));

--- a/src/test/java/seedu/address/model/finance/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/finance/DescriptionTest.java
@@ -11,6 +11,12 @@ public class DescriptionTest {
     public void constructor_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Description(null));
     }
+
+    @Test
+    public void constructor_emptyString_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new Description(""));
+    }
+
     @Test
     public void isValidDescription() {
         // null description
@@ -26,8 +32,9 @@ public class DescriptionTest {
                 + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); // 257 characters
 
         assertFalse(Description.isValidDescription(" ")); // whitespace
+        assertFalse(Description.isValidDescription("")); // blank
+
         //valid description
-        assertTrue(Description.isValidDescription("")); // blank
         assertTrue(Description.isValidDescription("Test description 123")); // alphanumeric only
     }
 

--- a/src/test/java/seedu/address/model/finance/ExpenseTest.java
+++ b/src/test/java/seedu/address/model/finance/ExpenseTest.java
@@ -31,7 +31,7 @@ public class ExpenseTest {
 
     @Test
     public void getDescription_returnsCorrectDescription() {
-        assertEquals(EXPENSE_TWENTY_TO_G.getDescription(), new Description(""));
+        assertEquals(EXPENSE_TWENTY_TO_G.getDescription(), new Description("Test commission"));
         assertEquals(EXPENSE_THIRTY_TO_K.getDescription(), new Description("Extra"));
     }
 
@@ -40,11 +40,11 @@ public class ExpenseTest {
         Expense expense = new ExpenseBuilder()
                 .withAmount("2103")
                 .withPerson("Test")
-                .withDescription("").build();
+                .build();
         Expense similarExpense = new ExpenseBuilder()
                 .withAmount("2103")
                 .withPerson("Test")
-                .withDescription("").build();
+                .build();
 
         assertTrue(expense.haveSameFields(similarExpense));
     }
@@ -54,11 +54,11 @@ public class ExpenseTest {
         Expense expense = new ExpenseBuilder()
                 .withAmount("2103")
                 .withPerson("Not test")
-                .withDescription("").build();
+                .build();
         Expense similarExpense = new ExpenseBuilder()
                 .withAmount("2103")
                 .withPerson("Test")
-                .withDescription("").build();
+                .build();
 
         assertFalse(expense.haveSameFields(similarExpense));
     }

--- a/src/test/java/seedu/address/storage/events/JsonAdaptedEventTest.java
+++ b/src/test/java/seedu/address/storage/events/JsonAdaptedEventTest.java
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.event.EventDescription;
 import seedu.address.model.event.EventName;
 import seedu.address.model.event.Location;
 import seedu.address.model.event.TimeEnd;
 import seedu.address.model.event.TimeStart;
-import seedu.address.model.finance.Description;
 import seedu.address.storage.JsonAdaptedPerson;
 
 public class JsonAdaptedEventTest {
@@ -113,7 +113,7 @@ public class JsonAdaptedEventTest {
         JsonAdaptedEvent event =
                 new JsonAdaptedEvent(VALID_NAME, VALID_START_TIME, VALID_END_TIME, VALID_LOCATION,
                         INVALID_DESCRIPTION, VALID_CLIENTS);
-        String expectedMessage = Description.MESSAGE_CONSTRAINTS;
+        String expectedMessage = EventDescription.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, event::toModelType);
     }
 }

--- a/src/test/java/seedu/address/testutil/CommissionBuilder.java
+++ b/src/test/java/seedu/address/testutil/CommissionBuilder.java
@@ -51,9 +51,12 @@ public class CommissionBuilder {
 
     /**
      * Sets the {@code Description} of the {@code Commission} that we are building.
+     * No changes if the description is an empty string.
      */
     public CommissionBuilder withDescription(String description) {
-        this.description = new Description(description);
+        if (!description.trim().equals("")) {
+            this.description = new Description(description);
+        }
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ExpenseBuilder.java
+++ b/src/test/java/seedu/address/testutil/ExpenseBuilder.java
@@ -54,6 +54,9 @@ public class ExpenseBuilder {
      * Sets the {@code Description} of the {@code Expense} that we are building.
      */
     public ExpenseBuilder withDescription(String description) {
+        if (!description.trim().equals("")) {
+            this.description = new Description(description);
+        }
         this.description = new Description(description);
         return this;
     }

--- a/src/test/java/seedu/address/testutil/TypicalFinances.java
+++ b/src/test/java/seedu/address/testutil/TypicalFinances.java
@@ -16,7 +16,7 @@ public class TypicalFinances {
     public static final Commission COMMISSION_TEN_FROM_T = new CommissionBuilder()
             .withAmount("10")
             .withPerson("T")
-            .withDescription("")
+            .withDescription("Test commission")
             .build();
     public static final Commission COMMISSION_TWENTY_FROM_H = new CommissionBuilder()
             .withAmount("20")
@@ -27,7 +27,7 @@ public class TypicalFinances {
     public static final Expense EXPENSE_TWENTY_TO_G = new ExpenseBuilder()
             .withAmount("20")
             .withPerson("G")
-            .withDescription("")
+            .withDescription("Test commission")
             .build();
     public static final Expense EXPENSE_THIRTY_TO_K = new ExpenseBuilder()
             .withAmount("30")


### PR DESCRIPTION
As discussed,

1. Changed description for Finance (both Expense and Commission) to be a mandatory field.
2. Specifically, parameter constraint has changed to a **non-empty string not longer than 256 characters**.
3. Updated builders in testutil to reflect this change and usage of `.withDescription(String desc)` method with an empty string results in no changes to the builder instance
4. Swapped positions of client and description in UI