### PR TITLE
Fix Bug: Related to Client Checking in Events

### DIFF
--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -116,7 +116,9 @@ public class Event implements Comparable<Event> {
         return eventName.equals(otherEvent.eventName)
                 && timeStart.equals(otherEvent.timeStart)
                 && timeEnd.equals(otherEvent.timeEnd)
-                && clients.equals(otherEvent.clients)
+                && clients.stream().allMatch(client -> otherEvent.clients.stream().anyMatch(
+                        otherClient -> client.isSamePerson(otherClient)))
+                && clients.size() == otherEvent.clients.size()
                 && location.equals(otherEvent.location)
                 && eventDescription.equals(otherEvent.eventDescription);
     }

--- a/src/test/java/seedu/address/logic/parser/events/EventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/events/EventParserTest.java
@@ -35,7 +35,6 @@ import seedu.address.model.event.EventNameContainsKeywordsPredicate;
 import seedu.address.model.event.EventTimeBeforePredicate;
 import seedu.address.testutil.EventBuilder;
 import seedu.address.testutil.EventUtil;
-import seedu.address.testutil.PersonBuilder;
 
 public class EventParserTest {
 
@@ -46,10 +45,11 @@ public class EventParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Event event = new EventBuilder().withClient(ALICE).build();
-        model.addPerson(new PersonBuilder().withName("Alice").build());
         AddEventCommand command = (AddEventCommand) parser.parseCommand(EventUtil.getAddCommand(event));
+        ModelManager expectedModel = new ModelManager(getTypicalPersonsBook(), new EventsBook(), new FinancesBook(),
+                new UserPrefs());
 
-        assertEquals(new AddEventCommand(event).execute(model), command.execute(model));
+        assertEquals(new AddEventCommand(event).execute(model), command.execute(expectedModel));
     }
 
     @Test
@@ -103,8 +103,6 @@ public class EventParserTest {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
-
-    /* TODO IMPLEMENT FIND TEST WHEN IMPLEMENTED */
 
     @Test
     public void parseCommand_help() throws Exception {

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.Person;
+import seedu.address.testutil.EventBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 public class EventTest {
@@ -81,6 +82,20 @@ public class EventTest {
                 new TimeStart(startTime), new TimeEnd(endTime), new HashSet<>(),
                 new Location(""), new EventDescription(""));
         assertFalse(event1.equals(event3));
+    }
+
+    @Test
+    public void equals_clients() {
+        // Test with same event name, start time and end time
+        Event event1 = new EventBuilder().withClient(ALICE).build();
+        Event event2 = new EventBuilder().withClient(new PersonBuilder().withName("Alice Pauline").build()).build();
+        assertTrue(event1.equals(event2));
+
+        Event event3 = new EventBuilder().withClient(new PersonBuilder().withName("Alice").build()).build();
+        Event event4 = new EventBuilder().withClient(new PersonBuilder().withName("Alice").build())
+                .withClient(ALICE).build();
+        assertFalse(event1.equals(event3));
+        assertFalse(event1.equals(event4));
     }
 
 }


### PR DESCRIPTION
* Initially client check compares `Set<Client>`
* Now `equals` checks for Set size and if each element is a subset of the other `Set<Client>`
* Update test file to check for more cases of Events with different clients
* Update EventParserTest with expectedModel as there cannot be the same Event in the same EventsBook