### PR TITLE
Fix bug CSS file throws `IllegalArgumentFunctionality` Exception

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -357,10 +357,6 @@
     -fx-font-size: 1.2em;
 }
 
-.tab .tab-label {
-    -fx-alignment: BOTTOM;
-}
-
 .tab {
     -fx-background-radius: 5 5 0 0;
     -fx-background-insets: 10 1 0 1;

--- a/src/test/resources/view/DarkTheme.css
+++ b/src/test/resources/view/DarkTheme.css
@@ -313,9 +313,6 @@
     -fx-font-size: 1.2em;
 }
 
-.tab .tab-label {
-    -fx-alignment: BOTTOM;
-}
 .tab {
     -fx-background-radius: 5 5 0 0;
     -fx-background-insets: 10 1 0 1;


### PR DESCRIPTION
* Remove `.tab .tab-label` css class (not used)

Closes #172 
Remove reason why the exception was thrown in the first place